### PR TITLE
Use the appropriate style property for the ```theme.json```.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3,7 +3,9 @@
     "name": "Context Menu Icons",
     "description": "Bring the icon of the context menu back to Zen browser ",
     "homepage": "https://github.com/1247343406/context-menu-icons-for-Zen",
-    "style": "https://raw.githubusercontent.com/1247343406/context-menu-icons-for-Zen/refs/heads/main/userChrome.css",
+    "style": {
+        "chrome": "https://raw.githubusercontent.com/1247343406/context-menu-icons-for-Zen/refs/heads/main/userChrome.css"
+    },
     "readme": "https://raw.githubusercontent.com/1247343406/context-menu-icons-for-Zen/refs/heads/main/README.md",
     "author": "1247343406",
     "version": "1.0.0",


### PR DESCRIPTION
A new build of Cosine will be allowing for svgs, ttfs, and any other file type that is imported using url(). As a result, I have reviewed this repository's theme.json for Sine support and noticed it was missing a little property that Sine uses to clarify between userChrome and userContent. With this new fix, it should work completely with an upcoming build of Cosine.

*Sorry for the terrible wording, just trying to get stuff done.*
@1247343406