### PR TITLE
Update mod to only show on Zen.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -16,5 +16,6 @@
         "Icon Pack"
     ],
     "createdAt": "2025-06-02",
-    "updatedAt": "2025-06-02"
+    "updatedAt": "2025-06-02",
+    "fork": ["zen"]
 }

--- a/theme.json
+++ b/theme.json
@@ -17,5 +17,5 @@
     ],
     "createdAt": "2025-06-02",
     "updatedAt": "2025-06-02",
-    "fork": ["zen"]
+    "fork": ["zen", "firefox"]
 }


### PR DESCRIPTION
@1247343406 In an upcoming version of Sine, it will be compatible with multiple browsers. Along with this major change, I will be adding a fork property to mods so that they will only be shown if the user is on a Firefox browser that corresponds with the ones the mod allows. That's what this pr does.